### PR TITLE
Emit events from Bridge object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./constants";
-export { Bridge } from "./bridge";
+export { Bridge, BridgeState } from "./bridge";
+export { GameStartType, GameEndType, PlayerType } from "@slippi/slippi-js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./constants";
-export { Bridge, BridgeEvent } from "./bridge";
+export { Bridge, BridgeEvent, DisconnectReason } from "./bridge";
 export { GameStartType, GameEndType, PlayerType } from "@slippi/slippi-js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./constants";
-export { Bridge, BridgeState } from "./bridge";
+export { Bridge, BridgeEvent } from "./bridge";
 export { GameStartType, GameEndType, PlayerType } from "@slippi/slippi-js";


### PR DESCRIPTION
To track the progress of a connection and what is happening on the bridge, this PR has the `Bridge` class extend `EventEmitter`. It can emit the following events:

- `WS_CONNECTED`
- `SLIPPI_CONNECTED`
- `GAME_START` (includes payload of `GameStartType` from slippi-js
- `GAME_END`
- DISCONNECTED` (includes payload of `DisconnectReason`).

The `DISCONNECTED` event is emitted for all disconnections except, currently, generic errors. 