### PR TITLE
Direct connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # slippi-web-bridge
 
-A simple forwarder for Slippi live games to a WebSocket connection.
+Forward Slippi spectate streams to WebSocket connections.
+
+## Usage
+
+`npm i slippi-web-bridge`
+
+```js
+import { Bridge } from "slippi-web-bridge";
+const options = {}; // documented below
+const bridge = new Bridge(options);
+```
+
+The constructor opens a WebSocket server to serve the game data unless the `server: false` options is passed.
+
+The bridge options are:
+- `server`:
+  * `port`: the port to serve the WebSocket server on (`number`, default `4102`)
+- `slippi`:
+  * `address`: the address to read Slippi data from (`string`, default `"127.0.0.1"`)
+  * `port`: the port to read Slippi data from (`number`, default `Ports.DEFAULT` from slippi-js)

--- a/examples/runLocal.js
+++ b/examples/runLocal.js
@@ -1,0 +1,14 @@
+const { Bridge, BridgeEvent } = require("../dist/index.js");
+
+// The websocket URL SpectatorMode
+const LOCAL_WS_URL = "ws://localhost:4000/bridge_socket/websocket";
+
+const bridge = new Bridge();
+
+bridge.on(BridgeEvent.SLIPPI_CONNECTED, () => {
+  bridge.connectToRelayServer(LOCAL_WS_URL);
+});
+
+bridge.on(BridgeEvent.DISCONNECTED, () => {
+  process.exit();
+});

--- a/examples/runRelayOnly.js
+++ b/examples/runRelayOnly.js
@@ -1,0 +1,14 @@
+const { Bridge, BridgeEvent } = require("../dist/index.js");
+
+// The websocket URL SpectatorMode
+const SM_WS_URL = "ws://spectator-mode.fly.dev/bridge_socket/websocket";
+
+const bridge = new Bridge({ server: false });
+
+bridge.on(BridgeEvent.SLIPPI_CONNECTED, () => {
+  bridge.connectToRelayServer(SM_WS_URL);
+});
+
+bridge.on(BridgeEvent.DISCONNECTED, () => {
+  process.exit();
+});

--- a/examples/runServer.js
+++ b/examples/runServer.js
@@ -1,0 +1,7 @@
+const { Bridge, BridgeEvent } = require("../dist/index.js");
+
+const bridge = new Bridge();
+
+bridge.on(BridgeEvent.DISCONNECTED, () => {
+  process.exit();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
-        "@slippi/slippi-js": "^6.7.0"
+        "@slippi/slippi-js": "^6.7.0",
+        "ws": "^8.18.1"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -36,9 +37,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -208,6 +209,27 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -r dist/",
-    "sandbox": "npm run build && node dist/runLocal.js"
+    "clean": "rm -r dist/"
   },
   "author": "Graham Preston",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -r dist/"
+    "clean": "rm -r dist/",
+    "sandbox": "npm run build && node dist/runLocal.js"
   },
   "author": "Graham Preston",
   "license": "ISC",
@@ -23,6 +24,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "@slippi/slippi-js": "^6.7.0"
+    "@slippi/slippi-js": "^6.7.0",
+    "ws": "^8.18.1"
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -33,7 +33,7 @@ export enum DisconnectReason {
   QUIT = "swb-quit"
 }
 
-type BridgeOptions = {
+export type BridgeOptions = {
   server?: { port: number } | false,
   slippi?: {
     address?: string,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,4 +2,4 @@ import { Ports } from "@slippi/slippi-js";
 
 export const SLIPPI_LOCAL_ADDR = "127.0.0.1";
 export const SLIPPI_PORTS = Ports;
-export const DEFAULT_WEB_URL = "wss://spectator-mode.fly.dev/bridge_socket/websocket";
+export const WSS_DEFAULT_PORT = 4102;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./constants";
-export { Bridge, BridgeEvent, DisconnectReason } from "./bridge";
+export { Bridge, BridgeOptions, BridgeEvent, DisconnectReason } from "./bridge";
 export { GameStartType, GameEndType, PlayerType } from "@slippi/slippi-js";

--- a/src/runLocal.ts
+++ b/src/runLocal.ts
@@ -2,8 +2,5 @@ import { Bridge, SLIPPI_LOCAL_ADDR, SLIPPI_PORTS } from ".";
 
 const LOCAL_WEB = "ws://localhost:4000/bridge_socket/websocket";
 
-new Bridge(
-  SLIPPI_LOCAL_ADDR,
-  SLIPPI_PORTS.DEFAULT,
-  LOCAL_WEB
-);
+const bridge = new Bridge();
+bridge.connect(SLIPPI_LOCAL_ADDR, SLIPPI_PORTS.DEFAULT, LOCAL_WEB);

--- a/src/runLocal.ts
+++ b/src/runLocal.ts
@@ -1,6 +1,0 @@
-import { Bridge, SLIPPI_LOCAL_ADDR, SLIPPI_PORTS } from ".";
-
-const LOCAL_WEB = "ws://localhost:4000/bridge_socket/websocket";
-
-const bridge = new Bridge();
-bridge.connect(SLIPPI_LOCAL_ADDR, SLIPPI_PORTS.DEFAULT, LOCAL_WEB);


### PR DESCRIPTION
Adds the ability to launch a websocket server so that other websocket clients can be served directly. This is enabled by default, and can be turned off by constructing with `{ server: false }`. 